### PR TITLE
Add logging, exception handling, and AWS client class

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,7 @@ x-default: &node
     - ./config:/tmp/config:ro
     - ./config/spark-defaults.conf:/opt/bitnami/spark/conf/spark-defaults.conf:ro
     - ./target:/tmp/target:rw
+    - ./logs:/tmp/logs:rw
   secrets:
     - AWS_CREDENTIALS
     - GH_PEM

--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -136,11 +136,16 @@ def main():
     new_local_files = []
     for job in jobs:
         job_upload_results = job.upload(aws)
-        new_local_files.append(job_upload_results)
+        new_local_files.extend(job_upload_results)
 
     # If any jobs uploaded never-seen-before files, trigger a Glue crawler
-    if any(new_local_files):
-        session.logger.info("New partitions uploaded, triggering Glue crawler")
+    if new_local_files:
+        session.logger.info(
+            (
+                f"{len(new_local_files)} previously unseen files uploaded to S3, "
+                "triggering Glue crawler"
+            )
+        )
         aws.run_and_wait_for_crawler("ccao-data-warehouse-iasworld-crawler")
 
     # Trigger a GitHub workflow to run dbt tests once all jobs are complete

--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -151,9 +151,12 @@ def main():
         workflow="test_dbt_models.yaml",
     )
 
-    # Print job descriptions for extracted tables and total elapsed time
-    job_descriptions = list(map(lambda j: j.get_description(), jobs))
-    session.logger.info(f"Extracted tables: {' | '.join(job_descriptions)}")
+    # Print table names for extracted tables and total elapsed time. The
+    # get_description() call is to print the description of each table to logs
+    session.logger.info(f"Extracted tables: {', '.join(table_names)}")
+    for job in jobs:
+        job.get_description()
+
     time_end = time.time()
     time_duration = str(timedelta(seconds=(time_end - time_start)))
     session.logger.info(f"Total extraction duration was {time_duration}")

--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -170,11 +170,10 @@ def submit_jobs(
         workflow="test_dbt_models.yaml",
     )
 
-    # Print table names for extracted tables and total elapsed time. The
-    # get_description() call is to print the description of each table to logs
+    # Print table names and descriptions for extracted tables
     logger.info(f"Extracted tables: {', '.join(table_names)}")
     for job in jobs:
-        job.get_description()
+        logger.info(job.get_description())
 
     time_end = time.time()
     time_duration = str(timedelta(seconds=(time_end - time_start)))

--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -4,12 +4,13 @@ from datetime import datetime, timedelta
 
 from joblib import Parallel, delayed
 from utils.aws import AWSClient
+from utils.github import GitHubClient
 from utils.helpers import (
+    PATH_SPARK_LOG,
     create_python_logger,
     load_job_definitions,
     load_predicates,
 )
-from utils.github import GitHubClient
 from utils.spark import SharedSparkSession, SparkJob
 
 logger = create_python_logger(__name__)
@@ -193,5 +194,5 @@ if __name__ == "__main__":
     aws.upload_logs_to_cloudwatch(
         log_group_name="/ccao/jobs/spark",
         log_stream_name=app_name,
-        log_file_path="/tmp/logs/spark.log",
+        log_file_path=PATH_SPARK_LOG,
     )

--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -173,6 +173,7 @@ def submit_jobs(
 
     # Print table names and descriptions for extracted tables
     logger.info(f"Extracted tables: {', '.join(table_names)}")
+    logger.info("Extracted tables using the following settings:")
     for job in jobs:
         logger.info(job.get_description())
 

--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -151,7 +151,9 @@ def main():
         workflow="test_dbt_models.yaml",
     )
 
-    session.logger.info(f"Extracted tables: {', '.join(table_names)}")
+    # Print job descriptions for extracted tables and total elapsed time
+    job_descriptions = list(map(lambda j: j.get_description(), jobs))
+    session.logger.info(f"Extracted tables: {' | '.join(job_descriptions)}")
     time_end = time.time()
     time_duration = str(timedelta(seconds=(time_end - time_start)))
     session.logger.info(f"Total extraction duration was {time_duration}")

--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -145,7 +145,7 @@ def main():
 
     # Trigger a GitHub workflow to run dbt tests once all jobs are complete
     session.logger.info("All file uploads complete, triggering dbt tests")
-    github = GitHubClient(gh_pem_path=PATH_GH_PEM)
+    github = GitHubClient(logger=session.logger, gh_pem_path=PATH_GH_PEM)
     github.run_workflow(
         repository="https://api.github.com/repos/ccao-data/data-architecture",
         workflow="test_dbt_models.yaml",

--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -156,6 +156,13 @@ def main():
     time_duration = str(timedelta(seconds=(time_end - time_start)))
     session.logger.info(f"Total extraction duration was {time_duration}")
 
+    # Upload final logs to CloudWatch
+    aws.upload_logs_to_cloudwatch(
+        log_group_name="/ccao/jobs/spark",
+        log_stream_name=session.app_name,
+        log_file_path=session.log_file_path,
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/src/utils/aws.py
+++ b/src/utils/aws.py
@@ -106,5 +106,9 @@ class AWSClient:
             )
             print("Successfully uploaded log file to CloudWatch")
 
+            # Remove the log file after successful upload
+            os.remove(log_file_path)
+            print(f"Successfully removed log file: {log_file_path}")
+
         except Exception as e:
             print(f"Failed to upload log file to CloudWatch: {e}")

--- a/src/utils/aws.py
+++ b/src/utils/aws.py
@@ -1,0 +1,39 @@
+import boto3
+import logging
+import os
+import time
+
+
+class SharedAWSClient:
+    def __init__(self, logger: logging.Logger):
+        """
+        Class to store AWS clients and methods for various AWS actions.
+
+        Attributes:
+            logger: Spark session logger that outputs to shared file in the
+                same format.
+            glue_client: Glue client connection. Instantiated from secrets file.
+            s3_client: S3 client connection. Instantiated from secrets file.
+            s3_bucket: S3 bucket to upload extracts to.
+            s3_prefix: S3 path prefix within S3 bucket. Defaults to "iasworld".
+        """
+        self.logger = logger
+        self.glue_client = boto3.client("glue")
+        self.s3_client = boto3.client("s3")
+        self.s3_bucket = os.getenv("AWS_S3_BUCKET")
+        self.s3_prefix = os.getenv("AWS_S3_PREFIX", "iasworld")
+
+    def run_and_wait_for_crawler(self, crawler_name):
+        self.logger.info(f"Starting AWS Glue crawler {crawler_name}")
+        self.glue_client.start_crawler(Name=crawler_name)
+
+        # Wait for the crawler to complete
+        while True:
+            response = self.glue_client.get_crawler(Name=crawler_name)
+            state = response["Crawler"]["State"]
+            if state == "READY":
+                self.logger.info(f"Crawler {crawler_name} has completed.")
+                break
+            elif state == "RUNNING":
+                self.logger.info(f"Crawler {crawler_name} is still running...")
+            time.sleep(30)

--- a/src/utils/aws.py
+++ b/src/utils/aws.py
@@ -62,8 +62,10 @@ class AWSClient:
             time_elapsed += time_increment
         if not job_complete:
             self.logger.warn(
-                f"Crawler {crawler_name} was still running after the {timeout}s polling timeout; "
-                "continuing execution without confirming its status"
+                (
+                    f"Crawler {crawler_name} was still running after the {timeout}s"
+                    f"timeout; continuing execution without confirming its status"
+                )
             )
 
     def upload_logs_to_cloudwatch(

--- a/src/utils/aws.py
+++ b/src/utils/aws.py
@@ -40,8 +40,8 @@ class AWSClient:
             return
 
         # Wait for the crawler to complete before triggering dbt tests
-        time_start = time.time()
-        time_elapsed = 0.0
+        time_elapsed = 0
+        time_increment = 30
         while True:
             response = self.glue_client.get_crawler(Name=crawler_name)
             state = response["Crawler"]["State"]  # type: ignore
@@ -52,11 +52,11 @@ class AWSClient:
                 self.logger.info(
                     (
                         f"Crawler {crawler_name} is running: "
-                        f"{round(time_elapsed, 0)}s elapsed"
+                        f"{time_elapsed}s elapsed"
                     )
                 )
-            time.sleep(30)
-            time_elapsed += time.time() - time_start
+            time.sleep(time_increment)
+            time_elapsed += time_increment
 
     def upload_logs_to_cloudwatch(
         self, log_group_name: str, log_stream_name: str, log_file_path: str

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -86,7 +86,7 @@ class GitHubClient:
                     json=data,
                 )
                 response.raise_for_status()
-                logger.info(f"GH workflow triggered: {workflow}")
+                logger.info(f"GitHub workflow triggered: {workflow}")
 
             except Exception as e:
                 logger.error(f"GitHub workflow run failed: {e}")

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -89,4 +89,4 @@ class GitHubClient:
                 self.logger.info(f"GH workflow triggered: {workflow}")
 
             except Exception as e:
-                self.logger.error(f"GH workflow run failed: {e}")
+                self.logger.error(f"GitHub workflow run failed: {e}")

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -1,25 +1,25 @@
 import os
-import logging
 import time
 
 import jwt
 import requests
 
+from utils.helpers import create_python_logger
+
+logger = create_python_logger(__name__)
+
 
 class GitHubClient:
-    def __init__(self, logger: logging.Logger, gh_pem_path: str) -> None:
+    def __init__(self, gh_pem_path: str) -> None:
         """
         Class to generate and store the credentials associated with GitHub,
         along with methods to dispatch a GitHub Actions workflow.
 
         Attributes:
-            logger: Spark session logger that outputs to shared file in the
-                same format.
             gh_pem_path: Container path to the GitHub certificate file.
             gh_app_id: GitHub Application ID for running a workflow.
             gh_jwt: GitHub JSON Web Token for authenticating with the API.
         """
-        self.logger = logger
         self.gh_pem_path = gh_pem_path
         self.gh_app_id = os.getenv("GH_APP_ID")
         self.gh_jwt = self.create_jwt_token()
@@ -86,7 +86,7 @@ class GitHubClient:
                     json=data,
                 )
                 response.raise_for_status()
-                self.logger.info(f"GH workflow triggered: {workflow}")
+                logger.info(f"GH workflow triggered: {workflow}")
 
             except Exception as e:
-                self.logger.error(f"GitHub workflow run failed: {e}")
+                logger.error(f"GitHub workflow run failed: {e}")

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -5,7 +5,7 @@ import jwt
 import requests
 
 
-class SharedGitHubSession:
+class GitHubClient:
     def __init__(self, gh_pem_path: str) -> None:
         """
         Class to generate and store the credentials associated with GitHub,

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -3,14 +3,17 @@ import logging
 from pathlib import Path
 
 
-def create_fallback_logger(log_file: str) -> logging.Logger:
+def create_python_logger(
+    name: str, log_file_path: str = "/tmp/logs/spark.log"
+) -> logging.Logger:
     """
     Sets up a logger with the same output format and location as the primary
-    Spark logger from the JVM. Used as a fallback in case any part of the
+    Spark logger from the JVM. Also used as a fallback in case any part of the
     main job loop fails.
 
     Args:
-        log_file: String path to the log file where logs will be written.
+        name: Module name to use for the logger.
+        log_file_path: String path to the log file where logs will be written.
 
     Returns:
         logging.Logger: Generic logger with the same log format as Spark.
@@ -32,10 +35,10 @@ def create_fallback_logger(log_file: str) -> logging.Logger:
         datefmt="%d/%m/%y %H:%M:%S",
     )
 
-    logger = logging.getLogger(__name__)
+    logger = logging.getLogger(name)
     logger.setLevel(logging.INFO)
 
-    file_handler = logging.FileHandler(log_file, mode="a")
+    file_handler = logging.FileHandler(log_file_path, mode="a")
     file_handler.setFormatter(file_formatter)
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(stdout_formatter)

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -2,9 +2,11 @@ import json
 import logging
 from pathlib import Path
 
+PATH_SPARK_LOG = "/tmp/logs/spark.log"
+
 
 def create_python_logger(
-    name: str, log_file_path: str = "/tmp/logs/spark.log"
+    name: str, log_file_path: str = PATH_SPARK_LOG
 ) -> logging.Logger:
     """
     Sets up a logger with the same output format and location as the primary

--- a/src/utils/spark.py
+++ b/src/utils/spark.py
@@ -8,7 +8,11 @@ from pyarrow import dataset as ds
 from pyspark.sql import SparkSession
 
 from utils.aws import AWSClient
-from utils.helpers import create_python_logger, strip_table_prefix
+from utils.helpers import (
+    PATH_SPARK_LOG,
+    create_python_logger,
+    strip_table_prefix,
+)
 
 logger = create_python_logger(__name__)
 
@@ -69,9 +73,7 @@ class SharedSparkSession:
         self.spark = SparkSession.builder.appName(self.app_name).getOrCreate()
         self.create_spark_logger()
 
-    def create_spark_logger(
-        self, log_file_path: str = "/tmp/logs/spark.log"
-    ) -> None:
+    def create_spark_logger(self, log_file_path: str = PATH_SPARK_LOG) -> None:
         """
         Extract the logger from the JVM used by Spark, then modify it to write
         to the same log file used by the Python logger.

--- a/src/utils/spark.py
+++ b/src/utils/spark.py
@@ -238,7 +238,7 @@ class SparkJob:
         time_end = time.time()
         time_duration = str(timedelta(seconds=(time_end - time_start)))
         self.session.logger.info(
-            f"Table {self.table_name} finished extract in {time_duration}"
+            f"Table {self.table_name} extracted in {time_duration}"
         )
 
     def repartition(self) -> None:
@@ -369,7 +369,7 @@ class SparkJob:
         time_end = time.time()
         time_duration = str(timedelta(seconds=(time_end - time_start)))
         self.session.logger.info(
-            f"Table {self.table_name} finished upload in {time_duration}"
+            f"Table {self.table_name} uploaded in {time_duration}"
         )
 
         return bool(table_files - s3_files)

--- a/src/utils/spark.py
+++ b/src/utils/spark.py
@@ -201,21 +201,13 @@ class SparkJob:
         partitions = self.get_partitions()
 
         # Create a block of log messages at the start of each job
-        logger.info(
-            (
-                f"Table {self.table_name}: starting JDBC read job",
-                "with the following settings",
-            )
-        )
         logger.info(f"Table {self.table_name} description: {description}")
         if partitions:
-            partitions_join = ", ".join(partitions)
             logger.info(
-                f"Table {self.table_name} partitions: {partitions_join}"
+                f"Table {self.table_name} partitions: {', '.join(partitions)}"
             )
         if filter:
-            filter_join = " AND ".join(filter)
-            logger.info(f"Table {self.table_name} filter: {filter_join}")
+            logger.info(f"Table {self.table_name} filter: {filter}")
 
         # Must use the JDBC read method here since the normal spark.read()
         # doesn't accept predicates https://stackoverflow.com/a/48680140
@@ -267,6 +259,10 @@ class SparkJob:
         """
 
         time_start = time.time()
+        partitions = self.get_partitions()
+        parts = ", ".join(self.get_partitions()) if partitions else "None"
+        logger.info(f"Table {self.table_name} repartitioning with: {parts}")
+
         dataset = ds.dataset(
             source=self.initial_dir,
             format="parquet",

--- a/src/utils/spark.py
+++ b/src/utils/spark.py
@@ -156,8 +156,6 @@ class SparkJob:
         if self.cur:
             desc.append(f"cur=[{', '.join(self.cur)}]")
 
-        logger.info(f"Table {self.table_name} description: {', '.join(desc)}")
-
         return ", ".join(desc)
 
     def get_filter(self) -> str | None:
@@ -173,7 +171,6 @@ class SparkJob:
             filter.append(f"cur IN ({', '.join(quoted_cur)})")
 
         filter_join = " AND ".join(filter)
-        logger.info(f"Table {self.table_name} filter: {filter_join}")
 
         return filter_join if filter != [] else None
 
@@ -187,9 +184,6 @@ class SparkJob:
             partitions.append("taxyr")
         if self.cur:
             partitions.append("cur")
-        logger.info(
-            f"Table {self.table_name} partitions: {', '.join(partitions)}"
-        )
 
         return partitions
 
@@ -203,6 +197,23 @@ class SparkJob:
         description = self.get_description()
         filter = self.get_filter()
         partitions = self.get_partitions()
+
+        # Create a block of log messages at the start of each job
+        logger.info(
+            (
+                f"Table {self.table_name}: starting JDBC read job",
+                "with the following settings",
+            )
+        )
+        logger.info(f"Table {self.table_name} description: {description}")
+        if partitions:
+            partitions_join = ", ".join(partitions)
+            logger.info(
+                f"Table {self.table_name} partitions: {partitions_join}"
+            )
+        if filter:
+            filter_join = " AND ".join(filter)
+            logger.info(f"Table {self.table_name} filter: {filter_join}")
 
         # Must use the JDBC read method here since the normal spark.read()
         # doesn't accept predicates https://stackoverflow.com/a/48680140

--- a/src/utils/spark.py
+++ b/src/utils/spark.py
@@ -36,6 +36,7 @@ class SharedSparkSession:
         final_compression: The compression type final repartitioned Parquet
             files. Defaults to ztd.
         spark: The Spark session object.
+        log_file_path: The path to the log file for the Spark session.
         logger: The logger object for the Spark session.
     """
 
@@ -64,7 +65,9 @@ class SharedSparkSession:
         self.initial_compression = "snappy"
         self.final_compression = "zstd"
 
+        # Create the Spark session and logging
         self.spark = SparkSession.builder.appName(self.app_name).getOrCreate()
+        self.log_file_path = f"/tmp/logs/{self.app_name}.log"
         self.logger = self.get_logger()
 
     def get_logger(self):
@@ -84,10 +87,10 @@ class SharedSparkSession:
         # the addition of milliseconds
         layout = log4j.PatternLayout()
         layout.setConversionPattern(
-            "%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{1}: %m%n"
+            "%d{yyyy-MM-dd_HH:mm:ss.SSS} %p %c{1}: %m%n"
         )
         appender.setLayout(layout)
-        appender.setFile(f"/tmp/logs/{self.app_name}.log")
+        appender.setFile(self.log_file_path)
         appender.activateOptions()
 
         spark_logger.removeAllAppenders()

--- a/src/utils/spark.py
+++ b/src/utils/spark.py
@@ -285,7 +285,7 @@ class SparkJob:
             f"Table {self.table_name} repartitioned in {time_duration}"
         )
 
-    def upload(self, aws: AWSClient) -> bool:
+    def upload(self, aws: AWSClient) -> list[str]:
         """
         Upload the final partitioned Parquet files to S3. This clears the
         remote S3 equivalent of each local partition prior to upload in order
@@ -296,7 +296,7 @@ class SparkJob:
             aws: AWS client class container S3 connection/location details.
 
         Returns:
-            bool: Whether new (yet unseen) local keys were uploaded to S3.
+            list[str]: List of previously unseen files uploaded to S3.
         """
 
         time_start = time.time()
@@ -372,4 +372,5 @@ class SparkJob:
             f"Table {self.table_name} uploaded in {time_duration}"
         )
 
-        return bool(table_files - s3_files)
+        new_local_files = [f.as_posix() for f in list(table_files - s3_files)]
+        return new_local_files

--- a/src/utils/spark.py
+++ b/src/utils/spark.py
@@ -40,7 +40,9 @@ class SharedSparkSession:
         logger: The logger object for the Spark session.
     """
 
-    def __init__(self, app_name: str, password_file_path: str) -> None:
+    def __init__(
+        self, app_name: str, log_file_path: str, password_file_path: str
+    ) -> None:
         self.app_name = app_name
         self.password_file_path = password_file_path
 
@@ -67,7 +69,7 @@ class SharedSparkSession:
 
         # Create the Spark session and logging
         self.spark = SparkSession.builder.appName(self.app_name).getOrCreate()
-        self.log_file_path = f"/tmp/logs/{self.app_name}.log"
+        self.log_file_path = log_file_path
         self.logger = self.get_logger()
 
     def get_logger(self):


### PR DESCRIPTION
This PR adds logging and error handling using the log4j driver pulled from the Spark session context. I chose to use this logger rather than standard Python logging because I want to capture the Spark output and intersperse it with Python logging.

This PR also adds a new `AWSClient` class that can trigger Glue jobs and upload finished log files to CloudWatch. I refactored the GitHub session class to more closely match the AWS one.

Here's an example [log output in CloudWatch](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Fccao$252Fjobs$252Fspark/log-events/iasworld_2024-08-16_06-56-25).