### PR TITLE
Add system for coercing column-level data types

### DIFF
--- a/config/default_jobs.yaml
+++ b/config/default_jobs.yaml
@@ -196,22 +196,22 @@ test_jobs:
     max_year: null
     cur: null
     predicates_path: null
-  # addn:
-  #   table_name: iasworld.addn
-  #   min_year: *min_year
+  addn:
+    table_name: iasworld.addn
+    min_year: *min_year
   addrindx:
     table_name: iasworld.addrindx
     min_year: 2011
     max_year: 2013
-  # aprval:
-  #   table_name: iasworld.aprval
-  #   max_year: 2004
-  #   cur: ["Y"]
-  # sales:
-  #   table_name: iasworld.sales
-  #   min_year: null
-  #   max_year: null
-  # valclass:
-  #   table_name: iasworld.valclass
-  #   cur: null
-  #   predicates_path: null
+  aprval:
+    table_name: iasworld.aprval
+    max_year: 2004
+    cur: ["Y"]
+  sales:
+    table_name: iasworld.sales
+    min_year: null
+    max_year: null
+  valclass:
+    table_name: iasworld.valclass
+    cur: null
+    predicates_path: null

--- a/config/default_jobs.yaml
+++ b/config/default_jobs.yaml
@@ -1,4 +1,5 @@
-define: &min_year 2022
+define:
+  min_year: &min_year 2022
 
 # Jobs that run daily at 1AM, typically getting the 2 most
 # recent years of data for critical tables

--- a/config/default_jobs.yaml
+++ b/config/default_jobs.yaml
@@ -196,22 +196,22 @@ test_jobs:
     max_year: null
     cur: null
     predicates_path: null
-  addn:
-    table_name: iasworld.addn
-    min_year: *min_year
+  # addn:
+  #   table_name: iasworld.addn
+  #   min_year: *min_year
   addrindx:
     table_name: iasworld.addrindx
     min_year: 2011
     max_year: 2013
-  aprval:
-    table_name: iasworld.aprval
-    max_year: 2004
-    cur: ["Y"]
-  sales:
-    table_name: iasworld.sales
-    min_year: null
-    max_year: null
-  valclass:
-    table_name: iasworld.valclass
-    cur: null
-    predicates_path: null
+  # aprval:
+  #   table_name: iasworld.aprval
+  #   max_year: 2004
+  #   cur: ["Y"]
+  # sales:
+  #   table_name: iasworld.sales
+  #   min_year: null
+  #   max_year: null
+  # valclass:
+  #   table_name: iasworld.valclass
+  #   cur: null
+  #   predicates_path: null

--- a/config/default_settings.yaml
+++ b/config/default_settings.yaml
@@ -13,5 +13,5 @@ default_args:
 #   2. Global schema overrides, as defined below
 #   3. Table schema overrides, defined in table_definitions.yaml
 global_schema_overrides:
-  - deactivat: STRING
-  - taxyr: STRING
+  deactivat: STRING
+  taxyr: STRING

--- a/config/default_settings.yaml
+++ b/config/default_settings.yaml
@@ -1,10 +1,10 @@
 # Default arguments used for the CLI. Can be overridden using the corresponding
 # flag at runtime
 default_args:
-  run_github_workflow: False
-  run_glue_crawler: False
-  upload_logs: False
-  upload_data: False
+  run_github_workflow: True
+  run_glue_crawler: True
+  upload_logs: True
+  upload_data: True
 
 # Data type overrides are necessary to maintain parity/consistency with sqoop.
 # Schema overrides are defined in three places, with each overriding the last:

--- a/config/default_settings.yaml
+++ b/config/default_settings.yaml
@@ -1,14 +1,16 @@
 # Default arguments used for the CLI. Can be overridden using the corresponding
 # flag at runtime
 default_args:
-  run-github-workflow: True
-  run-glue-crawler: True
-  upload-logs: True
-  upload-data: True
+  run_github_workflow: False
+  run_glue_crawler: False
+  upload_logs: False
+  upload_data: False
 
-# Schema coercions used for every table. Note that these are used
-# even if the column does not exist in a given table; Spark will simply
-# ignore such overrides
+# Data type overrides are necessary to maintain parity/consistency with sqoop.
+# Schema overrides are defined in three places, with each overriding the last:
+#   1. By default, NUMBER Oracle types are converted to DECIMAL(10,0)
+#      and TIMESTAMP Oracle types are converted to STRING
+#   2. Global schema overrides, as defined below
+#   3. Table schema overrides, defined in table_definitions.yaml
 global_schema_overrides:
-  - iasw_id DECIMAL(38, 0)
-  - wen STRING
+  - deactivat: STRING

--- a/config/default_settings.yaml
+++ b/config/default_settings.yaml
@@ -14,3 +14,4 @@ default_args:
 #   3. Table schema overrides, defined in table_definitions.yaml
 global_schema_overrides:
   - deactivat: STRING
+  - taxyr: STRING

--- a/config/default_settings.yaml
+++ b/config/default_settings.yaml
@@ -1,0 +1,14 @@
+# Default arguments used for the CLI. Can be overridden using the corresponding
+# flag at runtime
+default_args:
+  run-github-workflow: True
+  run-glue-crawler: True
+  upload-logs: True
+  upload-data: True
+
+# Schema coercions used for every table. Note that these are used
+# even if the column does not exist in a given table; Spark will simply
+# ignore such overrides
+global_schema_overrides:
+  - iasw_id DECIMAL(38, 0)
+  - wen STRING

--- a/config/table_definitions.yaml
+++ b/config/table_definitions.yaml
@@ -7,136 +7,170 @@ tables:
     min_year: null
     has_cur: false
     has_parid: false
-    schema_overrides:
-      - ss_ext_date STRING
+
   addn:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+
   addrindx:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+    schema_overrides:
+      - xcoord: DECIMAL(15,8)
+      - ycoord: DECIMAL(15,8)
+
   aprval:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+
   asmt_all:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+
   asmt_hist:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+
   cname:
     min_year: null
     has_cur: true
     has_parid: false
+
   comdat:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+
   comnt:
     min_year: null
     has_cur: false
     has_parid: false
+
   cvleg:
     min_year: 1900
     has_cur: false
     has_parid: true
+
   cvown:
     min_year: 2001
     has_cur: false
     has_parid: false
+
   cvtran:
     min_year: 1900
     has_cur: false
     has_parid: false
+
   dedit:
     min_year: null
     has_cur: false
     has_parid: false
+
   dweldat:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+
   enter:
     min_year: null
     has_cur: false
     has_parid: false
+
   exadmn:
     min_year: 1998
     has_cur: true
     has_parid: true
+
   exapp:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+
   excode:
     min_year: 1993
     has_cur: true
     has_parid: false
+
   exdet:
     min_year: 1998
     has_cur: true
     has_parid: true
+
   htagnt:
     min_year: null
     has_cur: false
     has_parid: false
+
   htdates:
     min_year: 2021
     has_cur: false
     has_parid: true
+
   htpar:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+
   land:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+
   legdat:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+
   lpmod:
     min_year: null
     has_cur: false
     has_parid: false
+
   lpnbhd:
     min_year: null
     has_cur: false
     has_parid: false
+
   oby:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+
   owndat:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+
   pardat:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+
   permit:
     min_year: null
     has_cur: false
     has_parid: false
+
   rcoby:
     min_year: null
     has_cur: false
     has_parid: false
+
   sales:
     min_year: null
     has_cur: true
     has_parid: true
+
   splcom:
     min_year: 2021
     has_cur: false
     has_parid: false
+
   valclass:
     min_year: 2015
     has_cur: false

--- a/config/table_definitions.yaml
+++ b/config/table_definitions.yaml
@@ -1,0 +1,143 @@
+define: &global_min_year 1999
+
+# Table definitions containing the possible values to use for each table job,
+# as well as table-level schema overrides per column
+tables:
+  aasysjur:
+    min_year: null
+    has_cur: false
+    has_parid: false
+    schema_overrides:
+      - ss_ext_date STRING
+  addn:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  addrindx:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  aprval:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  asmt_all:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  asmt_hist:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  cname:
+    min_year: null
+    has_cur: true
+    has_parid: false
+  comdat:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  comnt:
+    min_year: null
+    has_cur: false
+    has_parid: false
+  cvleg:
+    min_year: 1900
+    has_cur: false
+    has_parid: true
+  cvown:
+    min_year: 2001
+    has_cur: false
+    has_parid: false
+  cvtran:
+    min_year: 1900
+    has_cur: false
+    has_parid: false
+  dedit:
+    min_year: null
+    has_cur: false
+    has_parid: false
+  dweldat:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  enter:
+    min_year: null
+    has_cur: false
+    has_parid: false
+  exadmn:
+    min_year: 1998
+    has_cur: true
+    has_parid: true
+  exapp:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  excode:
+    min_year: 1993
+    has_cur: true
+    has_parid: false
+  exdet:
+    min_year: 1998
+    has_cur: true
+    has_parid: true
+  htagnt:
+    min_year: null
+    has_cur: false
+    has_parid: false
+  htdates:
+    min_year: 2021
+    has_cur: false
+    has_parid: true
+  htpar:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  land:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  legdat:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  lpmod:
+    min_year: null
+    has_cur: false
+    has_parid: false
+  lpnbhd:
+    min_year: null
+    has_cur: false
+    has_parid: false
+  oby:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  owndat:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  pardat:
+    min_year: *global_min_year
+    has_cur: true
+    has_parid: true
+  permit:
+    min_year: null
+    has_cur: false
+    has_parid: false
+  rcoby:
+    min_year: null
+    has_cur: false
+    has_parid: false
+  sales:
+    min_year: null
+    has_cur: true
+    has_parid: true
+  splcom:
+    min_year: 2021
+    has_cur: false
+    has_parid: false
+  valclass:
+    min_year: 2015
+    has_cur: false
+    has_parid: false

--- a/config/table_definitions.yaml
+++ b/config/table_definitions.yaml
@@ -19,8 +19,8 @@ tables:
     has_cur: true
     has_parid: true
     schema_overrides:
-      - xcoord: DECIMAL(15,8)
-      - ycoord: DECIMAL(15,8)
+      xcoord: DECIMAL(15,8)
+      ycoord: DECIMAL(15,8)
   aprval:
     min_year: *global_min_year
     has_cur: true
@@ -50,9 +50,9 @@ tables:
     has_cur: false
     has_parid: true
     schema_overrides:
-      - xcoord: DECIMAL(15,8)
-      - ycoord: DECIMAL(15,8)
-      - zcoord: DECIMAL(15,8)
+      xcoord: DECIMAL(15,8)
+      ycoord: DECIMAL(15,8)
+      zcoord: DECIMAL(15,8)
   cvown:
     min_year: 2001
     has_cur: false
@@ -110,9 +110,9 @@ tables:
     has_cur: true
     has_parid: true
     schema_overrides:
-      - xcoord: DECIMAL(15,8)
-      - ycoord: DECIMAL(15,8)
-      - zcoord: DECIMAL(15,8)
+      xcoord: DECIMAL(15,8)
+      ycoord: DECIMAL(15,8)
+      zcoord: DECIMAL(15,8)
   lpmod:
     min_year: null
     has_cur: false

--- a/config/table_definitions.yaml
+++ b/config/table_definitions.yaml
@@ -1,18 +1,19 @@
-define: &global_min_year 1999
+define:
+  global_min_year: &global_min_year 1999
 
 # Table definitions containing the possible values to use for each table job,
-# as well as table-level schema overrides per column
+# as well as table-level schema overrides per column. Null values indicate
+# the column is not applicable to the table, or that there should be no
+# check on the possible value
 tables:
   aasysjur:
     min_year: null
     has_cur: false
     has_parid: false
-
   addn:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
-
   addrindx:
     min_year: *global_min_year
     has_cur: true
@@ -20,157 +21,134 @@ tables:
     schema_overrides:
       - xcoord: DECIMAL(15,8)
       - ycoord: DECIMAL(15,8)
-
   aprval:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
-
   asmt_all:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
-
   asmt_hist:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
-
   cname:
     min_year: null
     has_cur: true
     has_parid: false
-
   comdat:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
-
   comnt:
     min_year: null
     has_cur: false
     has_parid: false
-
   cvleg:
     min_year: 1900
     has_cur: false
     has_parid: true
-
+    schema_overrides:
+      - xcoord: DECIMAL(15,8)
+      - ycoord: DECIMAL(15,8)
+      - zcoord: DECIMAL(15,8)
   cvown:
     min_year: 2001
     has_cur: false
     has_parid: false
-
   cvtran:
     min_year: 1900
     has_cur: false
     has_parid: false
-
   dedit:
     min_year: null
     has_cur: false
     has_parid: false
-
   dweldat:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
-
   enter:
     min_year: null
     has_cur: false
     has_parid: false
-
   exadmn:
     min_year: 1998
     has_cur: true
     has_parid: true
-
   exapp:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
-
   excode:
     min_year: 1993
     has_cur: true
     has_parid: false
-
   exdet:
     min_year: 1998
     has_cur: true
     has_parid: true
-
   htagnt:
     min_year: null
     has_cur: false
     has_parid: false
-
   htdates:
     min_year: 2021
     has_cur: false
     has_parid: true
-
   htpar:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
-
   land:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
-
   legdat:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
-
+    schema_overrides:
+      - xcoord: DECIMAL(15,8)
+      - ycoord: DECIMAL(15,8)
+      - zcoord: DECIMAL(15,8)
   lpmod:
     min_year: null
     has_cur: false
     has_parid: false
-
   lpnbhd:
     min_year: null
     has_cur: false
     has_parid: false
-
   oby:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
-
   owndat:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
-
   pardat:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
-
   permit:
     min_year: null
     has_cur: false
     has_parid: false
-
   rcoby:
     min_year: null
     has_cur: false
     has_parid: false
-
   sales:
     min_year: null
     has_cur: true
     has_parid: true
-
   splcom:
     min_year: 2021
     has_cur: false
     has_parid: false
-
   valclass:
     min_year: 2015
     has_cur: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "jwt==1.3.1",
   "py4j==0.10.9.7",
   "pyarrow==17.0.0",
+  "pyyaml==6.0.0",
   "requests==2.32.3"
 ]
 

--- a/run.sh
+++ b/run.sh
@@ -3,5 +3,4 @@
 # Example command to execute test jobs in the Spark cluster
 # First run `docker compose up -d` in the repo root
 docker exec -it spark-node-master ./submit.sh \
-    --json-string "$(yq -o=json .test_jobs ./config/default_jobs.yaml)" \
-    # --no-run-github-workflow --no-upload-data
+    --json-string "$(yq -o=json .test_jobs ./config/default_jobs.yaml)"

--- a/run.sh
+++ b/run.sh
@@ -3,4 +3,4 @@
 # Example command to execute test jobs in the Spark cluster
 # First run `docker compose up -d` in the repo root
 docker exec -it spark-node-master ./submit.sh \
-    --json-string "$(yq -o=json .test_jobs ./config/default_jobs.yaml)"
+    --json-string "$(yq -o=json .full_jobs ./config/default_jobs.yaml)"

--- a/run.sh
+++ b/run.sh
@@ -3,4 +3,4 @@
 # Example command to execute test jobs in the Spark cluster
 # First run `docker compose up -d` in the repo root
 docker exec -it spark-node-master ./submit.sh \
-    --json-string "$(yq -o=json .full_jobs ./config/default_jobs.yaml)"
+    --json-string "$(yq -o=json .test_jobs ./config/default_jobs.yaml)"

--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -156,13 +156,11 @@ def submit_jobs(
             load_predicates(predicates_path) if predicates_path else None
         )
 
-        # Create schema overrides, combining global and table-specific values
+        # Combine lists of global and table schema overrides and flatten them
+        # into a single dictionary
         table_schema_overrides = table_definitions.get(
             strip_table_prefix(table_name), []
         ).get("schema_overrides", {})
-
-        # Combine lists of global and table schema overrides and flatten them
-        # into a single dictionary
         schema_overrides = flatten_schema_dicts(
             global_schema_overrides, table_schema_overrides
         )

--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -8,6 +8,7 @@ from utils.github import GitHubClient
 from utils.helpers import (
     PATH_SPARK_LOG,
     create_python_logger,
+    flatten_schema_dicts,
     load_job_definitions,
     load_predicates,
     load_yaml,
@@ -158,11 +159,13 @@ def submit_jobs(
         # Create schema overrides, combining global and table-specific values
         table_schema_overrides = table_definitions.get(
             strip_table_prefix(table_name), []
-        ).get("schema_overrides", [])
-        print(global_schema_overrides)
-        schema_overrides = global_schema_overrides + table_schema_overrides
-        print(schema_overrides)
-        schema_overrides = ", ".join(schema_overrides)
+        ).get("schema_overrides", {})
+
+        # Combine lists of global and table schema overrides and flatten them
+        # into a single dictionary
+        schema_overrides = flatten_schema_dicts(
+            global_schema_overrides, table_schema_overrides
+        )
 
         spark_job = SparkJob(
             session=session,

--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -8,7 +8,6 @@ from utils.github import GitHubClient
 from utils.helpers import (
     PATH_SPARK_LOG,
     create_python_logger,
-    flatten_schema_dicts,
     load_job_definitions,
     load_predicates,
     load_yaml,
@@ -159,11 +158,10 @@ def submit_jobs(
         # Combine lists of global and table schema overrides and flatten them
         # into a single dictionary
         table_schema_overrides = table_definitions.get(
-            strip_table_prefix(table_name), []
+            strip_table_prefix(table_name), {}
         ).get("schema_overrides", {})
-        schema_overrides = flatten_schema_dicts(
-            global_schema_overrides, table_schema_overrides
-        )
+        schema_overrides = global_schema_overrides.copy()
+        schema_overrides.update(table_schema_overrides)
 
         spark_job = SparkJob(
             session=session,

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -112,25 +112,6 @@ def dict_to_schema(d: dict) -> str:
     return ", ".join(f"{k} {v}" for k, v in d.items())
 
 
-def flatten_schema_dicts(
-    global_overrides: list[dict] | None, table_overrides: list[dict] | None
-) -> dict:
-    """
-    Flattens a list of dictionaries into a single dictionary.
-
-    Args:
-        d: List of dictionaries to flatten.
-
-    Returns:
-        dict: A single dictionary containing all key-value pairs from the input
-        dictionaries.
-    """
-    glb = {k: v for item in (global_overrides or []) for k, v in item.items()}
-    tab = {k: v for item in (table_overrides or []) for k, v in item.items()}
-    glb.update(tab)
-    return glb
-
-
 def load_job_definitions(
     json_file: str | None, json_string: str | None
 ) -> dict:

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -67,6 +67,7 @@ def create_python_logger(
     name: str, log_file_path: str = PATH_SPARK_LOG
 ) -> logging.Logger:
     """
+    Sets up a logger with the same output format and location as the primary
     Spark logger from the JVM. Also used as a fallback in case any part of the
     main job loop fails.
 
@@ -108,15 +109,6 @@ def create_python_logger(
 
 
 def dict_to_schema(d: dict) -> str:
-    """
-    Converts a dictionary to a string in the format 'k1 v1, k2 v2'.
-
-    Args:
-        d: Dictionary to convert.
-
-    Returns:
-        str: String representation of the dictionary.
-    """
     return ", ".join(f"{k} {v}" for k, v in d.items())
 
 

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -9,7 +9,6 @@ def create_python_logger(
     name: str, log_file_path: str = PATH_SPARK_LOG
 ) -> logging.Logger:
     """
-    Sets up a logger with the same output format and location as the primary
     Spark logger from the JVM. Also used as a fallback in case any part of the
     main job loop fails.
 

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import yaml
 from pathlib import Path
 
 PATH_SPARK_LOG = "/tmp/logs/spark.log"
@@ -105,6 +106,22 @@ def load_predicates(path: str) -> list[str]:
         predicates = [line.strip() for line in file.readlines()]
 
     return predicates
+
+
+def load_yaml(path: str, key: str):
+    """
+    Fetch values from from a static YAML file.
+
+    Args:
+        path: String path to a YAML file within the `config/` directory.
+        key: Arbitrary key to fetch values from the YAML file.
+
+    Returns: Values from the corresponding YAML key.
+    """
+    with open(path, mode="r") as file:
+        data = yaml.safe_load(file)
+    values = data.get(key)
+    return values
 
 
 def strip_table_prefix(table_name: str) -> str:

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -1,9 +1,66 @@
 import json
 import logging
-import yaml
 from pathlib import Path
 
+import yaml
+from pyspark.sql import DataFrame
+from pyspark.sql.types import DecimalType, StringType, TimestampType
+
 PATH_SPARK_LOG = "/tmp/logs/spark.log"
+
+
+def convert_datetime_columns(
+    df: DataFrame, ignore_cols: list[str]
+) -> DataFrame:
+    """
+    iasWorld stores datetimes via the TIMESTAMP data type, but historically
+    we converted these columns to strings to avoid messy type incompatibility
+    with Athena. This function converts TIMESTAMP columns to UTC datetime
+    strings. Columns specified via schema overrides will ignore this conversion.
+
+    Args:
+        df: Spark DataFrame with columns to convert.
+        ignore_cols: Ignore columns specified in this list during conversion.
+
+    Returns:
+        Spark DataFrame with TIMESTAMP columns converted to STRING.
+    """
+    for field in df.schema.fields:
+        if (
+            isinstance(field.dataType, TimestampType)
+            and field.name not in ignore_cols
+        ):
+            df = df.withColumn(field.name, df[field.name].cast(StringType()))
+    return df
+
+
+def convert_decimal_columns(
+    df: DataFrame, ignore_cols: list[str]
+) -> DataFrame:
+    """
+    iasWorld stores many columns as the generic NUMBER Oracle data type, but
+    almost always uses DECIMAL(10,0) for the actual values. This function
+    automatically converts all such columns to DECIMAL(10,0). Columns specified
+    via schema overrides will ignore this conversion.
+
+    Args:
+        df: Spark DataFrame with columns to convert.
+        ignore_cols: Ignore columns specified in this list during conversion.
+
+    Returns:
+        Spark DataFrame with NUMBER columns converted to DECIMAL(10,0).
+    """
+    for field in df.schema.fields:
+        if (
+            isinstance(field.dataType, DecimalType)
+            and field.dataType.precision == 38
+            and field.dataType.scale == 10
+            and field.name not in ignore_cols
+        ):
+            df = df.withColumn(
+                field.name, df[field.name].cast(DecimalType(10, 0))
+            )
+    return df
 
 
 def create_python_logger(
@@ -48,6 +105,38 @@ def create_python_logger(
     logger.addHandler(stream_handler)
 
     return logger
+
+
+def dict_to_schema(d: dict) -> str:
+    """
+    Converts a dictionary to a string in the format 'k1 v1, k2 v2'.
+
+    Args:
+        d: Dictionary to convert.
+
+    Returns:
+        str: String representation of the dictionary.
+    """
+    return ", ".join(f"{k} {v}" for k, v in d.items())
+
+
+def flatten_schema_dicts(
+    global_overrides: list[dict] | None, table_overrides: list[dict] | None
+) -> dict:
+    """
+    Flattens a list of dictionaries into a single dictionary.
+
+    Args:
+        d: List of dictionaries to flatten.
+
+    Returns:
+        dict: A single dictionary containing all key-value pairs from the input
+        dictionaries.
+    """
+    glb = {k: v for item in (global_overrides or []) for k, v in item.items()}
+    tab = {k: v for item in (table_overrides or []) for k, v in item.items()}
+    glb.update(tab)
+    return glb
 
 
 def load_job_definitions(


### PR DESCRIPTION
This PR adds a cascading system for coercing iasWorld data types during Spark extraction. This is necessary in order to match existing data types from Sqoop, create predictable types in Athena, and occasionally coerce the errant column to its proper type.

The PR adds three-levels of schema override, with more specific levels overriding more general ones:

1. Convert all Oracle `NUMERIC` types to `DECIMAL(10,0)` and all `TIMESTAMP` types to `STRING`.[1]
2. Add a global schema override that applies to all tables, defined in `config/default_settings.yaml`.
3. Add table-specific, column-specific overrides, defined in `config/table_definitions.yaml`.

Using this system, I successfully matched all types across the current `iasworld` schema and a temporary `test_iasworld` schema in Athena. I compared types using the script below.

[1]: All Oracle `NUMERIC` columns are read as `DECIMAL(38, 10)` by default. However, AFAICT nearly all such columns are actually integers, and the `NUMERIC` type is simply used to hold them in an unbounded way. Sqoop converts these columns to `DECIMAL(10, 0)` by first reading their value and then assigning the type. There is a non-zero chance that by coercing numbers to this type, we could begin silently truncating values _if_ they ever expand beyond 10,0.

<details>
<summary><strong>R script used to compare data types</strong></summary>

```r
library(noctua)
library(dplyr)
library(glue)
library(stringr)

AWS_ATHENA_CONN_NOCTUA <- dbConnect(noctua::Athena())
tables <- dbGetTables(AWS_ATHENA_CONN_NOCTUA, schema = "iasworld")$TableName

# Extract the types from the string DDL statement
get_col_types <- function(sql) {
  str_extract_all(sql, "`[a-z0-9_-]+` [a-z0-9\\)\\(,]*[,)]") %>%
    .[[1]] %>%
    str_remove_all("\\)$") %>%
    str_remove_all(",$") %>%
    str_remove_all("`") %>%
    tibble() %>%
    tidyr::separate(col = ".", into = c("col", "type"), sep = " ")
}

# Grab new and old DDLs for each table and munge them into one dataframe
types_df <- purrr::map_dfr(tables, \(table) {
  print(paste("scanning table:", table))
  old_ddl <- dbShow(AWS_ATHENA_CONN_NOCTUA, glue("iasworld.{table}"))
  new_ddl <- dbShow(AWS_ATHENA_CONN_NOCTUA, glue("test_iasworld.{table}"))

  old <- get_col_types(old_ddl)
  new <- get_col_types(new_ddl)

  merged <- old %>%
    left_join(new, by = "col", suffix = c("_old", "_new")) %>%
    mutate(table = {{ table }}) %>%
    relocate(table, .before = everything()) %>%
    mutate(no_match = type_old != type_new)

  merged
})
```
</details>