### PR TITLE
Fix log file deletion/write mode

### DIFF
--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import time
 from datetime import datetime, timedelta
 
@@ -17,7 +18,7 @@ from utils.helpers import (
 )
 from utils.spark import SharedSparkSession, SparkJob
 
-logger = create_python_logger(__name__, mode="w")
+logger = create_python_logger(__name__)
 
 # Default values for jobs, used per job if not explicitly set in the job's
 # input JSON. CUR and YEAR values are used for partitioning and filtering
@@ -263,11 +264,13 @@ if __name__ == "__main__":
     app_name = f"iasworld_{args.extract_target}_{current_datetime}"
 
     try:
-        # Clear the existing extract files before submitting new jobs.
+        # Clear the existing extract files and logs before submitting new jobs.
         # This is to prevent new jobs from becoming mixed with the results of
         # previous failed or cancelled jobs
         clear_directory(PATH_INITIAL_DIR)
         clear_directory(PATH_FINAL_DIR)
+        if os.path.exists(PATH_SPARK_LOG):
+            os.remove(PATH_SPARK_LOG)
 
         submit_jobs(
             app_name=app_name,

--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -257,6 +257,10 @@ def submit_jobs(
 
 
 if __name__ == "__main__":
+    # Clear any existing log file immediately on session start
+    if os.path.exists(PATH_SPARK_LOG):
+        os.remove(PATH_SPARK_LOG)
+
     current_datetime = datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
     default_args = load_yaml(PATH_DEFAULT_SETTINGS, "default_args")
     args = parse_args(default_args)
@@ -264,13 +268,11 @@ if __name__ == "__main__":
     app_name = f"iasworld_{args.extract_target}_{current_datetime}"
 
     try:
-        # Clear the existing extract files and logs before submitting new jobs.
+        # Clear the existing extract files before submitting new jobs.
         # This is to prevent new jobs from becoming mixed with the results of
         # previous failed or cancelled jobs
         clear_directory(PATH_INITIAL_DIR)
         clear_directory(PATH_FINAL_DIR)
-        if os.path.exists(PATH_SPARK_LOG):
-            os.remove(PATH_SPARK_LOG)
 
         submit_jobs(
             app_name=app_name,

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -29,7 +29,7 @@ def clear_directory(dir: Path | str) -> None:
 
 
 def create_python_logger(
-    name: str, mode: str = "a", log_file_path: str = PATH_SPARK_LOG
+    name: str, log_file_path: str = PATH_SPARK_LOG
 ) -> logging.Logger:
     """
     Sets up a logger with the same output format and location as the primary
@@ -38,7 +38,6 @@ def create_python_logger(
 
     Args:
         name: Module name to use for the logger.
-        mode: Logging handler mode when writing to file.
         log_file_path: String path to the log file where logs will be written.
 
     Returns:
@@ -64,7 +63,7 @@ def create_python_logger(
     logger = logging.getLogger(name)
     logger.setLevel(logging.INFO)
 
-    file_handler = logging.FileHandler(log_file_path, mode=mode)
+    file_handler = logging.FileHandler(log_file_path, mode="a")
     file_handler.setFormatter(file_formatter)
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(stdout_formatter)


### PR DESCRIPTION
We had some Spark alarms this weekend indicating that our jobs didn't run. They actually did, but the logs weren't written to CloudWatch due to changes from 2212877054a983ad484d735b01aeae1163cc8cee. This PR reverts those changes and moves the log removal to the beginning of the job removal script.