### PR TITLE
Fix filter pushdown

### DIFF
--- a/config/default_settings.yaml
+++ b/config/default_settings.yaml
@@ -13,6 +13,9 @@ default_args:
 #      and TIMESTAMP Oracle types are converted to STRING
 #   2. Global schema overrides, as defined below
 #   3. Table schema overrides, defined in table_definitions.yaml
+#
+# NOTE: taxyr MUST be an integer in order for Spark to properly pushdown
+# filters (and thus make queries go fast)
 global_schema_overrides:
   deactivat: STRING
-  taxyr: STRING
+  taxyr: INTEGER


### PR DESCRIPTION
This PR fixes filter pushdown for tables using `taxyr`. Previously, forcing the `taxyr` schema value to STRING caused filtering to be done _after_ this initial SQL pull.