### PR TITLE
Set var to upload test results when running GitHub workflow

### DIFF
--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -248,6 +248,7 @@ def submit_jobs(
         github.run_workflow(
             repository=(github.gh_api_url + "ccao-data/data-architecture"),
             workflow="test_dbt_models.yaml",
+            inputs={"upload_test_results": True},
         )
 
     # Print table names and descriptions for extracted tables

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -84,7 +84,7 @@ class GitHubClient:
                 response.raise_for_status()
                 gh_token = response.json()["token"]
 
-                data = {"ref": "master"}
+                data: dict[str, str | dict] = {"ref": "master"}
                 if inputs is not None:
                     data["inputs"] = inputs
 

--- a/src/utils/github.py
+++ b/src/utils/github.py
@@ -48,13 +48,16 @@ class GitHubClient:
 
         return encoded_jwt
 
-    def run_workflow(self, repository, workflow) -> None:
+    def run_workflow(
+        self, repository, workflow, inputs: dict | None = None
+    ) -> None:
         """
         Dispatch a GitHub Actions workflow using the GitHub API.
 
         Args:
             repository: API URL for the target repository containing a workflow.
             workflow: Workflow YAML file, relative to `.github/workflows`.
+            inputs: Optional dict of input variables.
         """
 
         def create_headers(bearer: str) -> dict:
@@ -82,6 +85,9 @@ class GitHubClient:
                 gh_token = response.json()["token"]
 
                 data = {"ref": "master"}
+                if inputs is not None:
+                    data["inputs"] = inputs
+
                 response = requests.post(
                     f"{repository}/actions/workflows/{workflow}/dispatches",
                     headers=create_headers(gh_token),


### PR DESCRIPTION
**⚠️ This PR depends on changes in https://github.com/ccao-data/data-architecture/pull/603. Make sure to merge that PR before this one. ⚠️** 

This PR updates the GitHub workflows integration in our Spark ingest config to pass the `upload_test_results=True` input variable when triggering the `test-dbt-models` workflow in https://github.com/ccao-data/data-architecture/. This parameter will be necessary in order to run the workflow properly once https://github.com/ccao-data/data-architecture/pull/603 lands.

Is there an easy way to test this change other than pulling this branch on the server and running a manual test? Perhaps I could clone a new copy of the repo, copy over the secrets, build the containers, and then run a test from the test repo? Let me know what you think the best path forward is for testing and I'll make sure to do it before pulling this PR in.