### PR TITLE
Update `github.run_workflow()` call to specify which tests to run

### DIFF
--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -248,7 +248,10 @@ def submit_jobs(
         github.run_workflow(
             repository=(github.gh_api_url + "ccao-data/data-architecture"),
             workflow="test_dbt_models.yaml",
-            inputs={"upload_test_results": True},
+            inputs={
+                "selector": "select_data_test_iasworld",
+                "upload_test_results": True,
+            },
         )
 
     # Print table names and descriptions for extracted tables


### PR DESCRIPTION
**⚠️ This PR depends on changes in https://github.com/ccao-data/data-architecture/pull/638. Make sure to merge that PR before this one. ⚠️** 

This companion PR of https://github.com/ccao-data/data-architecture/pull/638/ implements a simple one-line change to specify the [dbt selector](https://docs.getdbt.com/reference/node-selection/yaml-selectors) representing the tests that the Spark process should run when the `--run-github-workflow` option is enabled.

This change is necessary because https://github.com/ccao-data/data-architecture/pull/638/ changes the default set of tests that the workflow will run in the absence of a `select` or `selector` option.