### PR TITLE
Update Spark prod resources configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -98,8 +98,8 @@ services:
       <<: *spark-env
       SPARK_MODE: worker
       SPARK_MASTER_URL: spark://spark-node-master-prod:7077
-      SPARK_WORKER_MEMORY: 96g
-      SPARK_WORKER_CORES: 32
+      SPARK_WORKER_MEMORY: 96G
+      SPARK_WORKER_CORES: 28
       SPARK_WORKER_WEBUI_PORT: 9090
     ports:
       - 9090:9090


### PR DESCRIPTION
I goofed and bumped the core count to 32 in #22. This results in OOM errors on our server. Lowering the core count to 28 prevents this.