### PR TITLE
Call new workflow for running iasWorld tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,13 @@ used by default (with no profile specified).
 To start the development environment, run:
 
 ```bash
+# Make sure to export your UID, or else Spark may run into permission problems
+# when trying to write to files in your local directory
+export UID
+# Start the development services
 docker compose up -d
-# OR run
+# OR pass in the --profiles flag to explicitly start development services (this
+# is equivalent to the command above)
 docker compose --profile dev up -d
 ```
 

--- a/src/submit_jobs.py
+++ b/src/submit_jobs.py
@@ -246,9 +246,8 @@ def submit_jobs(
         github = GitHubClient(gh_pem_path=PATH_GH_PEM)
         github.run_workflow(
             repository=(github.gh_api_url + "ccao-data/data-architecture"),
-            workflow="test_dbt_models.yaml",
+            workflow="test_iasworld_data.yaml",
             inputs={
-                "selector": "select_data_test_iasworld",
                 "upload_test_results": True,
             },
         )


### PR DESCRIPTION
> [!WARNING]
> This PR depends on changes in https://github.com/ccao-data/data-architecture/pull/671. Do not merge it before merging that PR.

This PR updates our Spark process to call the new name of the workflow that we will use for running iasWorld data tests starting in https://github.com/ccao-data/data-architecture/pull/671.

Note that we can't actually test this change until we merge https://github.com/ccao-data/data-architecture/pull/671, since the workflow will not be dispatchable until it lands on the master branch. I'll run a quick test before merging this and fix any problems that I notice.