### PR TITLE
Add schema overrides for land rate columns

### DIFF
--- a/config/table_definitions.yaml
+++ b/config/table_definitions.yaml
@@ -105,6 +105,20 @@ tables:
     min_year: *global_min_year
     has_cur: true
     has_parid: true
+    # Override land rates that are stored as NUMBER types with no set precision
+    # or scale, meaning they default to the maximum precision and scale that
+    # Oracle supports (38 and 127, respectively). Presto performance is best up
+    # to a precision of 18, so we set precision to that high bar and truncate
+    # scale to a high but reasonable value.
+    schema_overrides:
+      bdecr: DECIMAL(18,10)
+      bincr: DECIMAL(18,10)
+      brate: DECIMAL(18,10)
+      bsize: DECIMAL(18,10)
+      odecr: DECIMAL(18,10)
+      oincr: DECIMAL(18,10)
+      orate: DECIMAL(18,10)
+      osize: DECIMAL(18,10)
   legdat:
     min_year: *global_min_year
     has_cur: true

--- a/config/table_definitions.yaml
+++ b/config/table_definitions.yaml
@@ -109,7 +109,8 @@ tables:
     # or scale, meaning they default to the maximum precision and scale that
     # Oracle supports (38 and 127, respectively). Presto performance is best up
     # to a precision of 18, so we set precision to that high bar and truncate
-    # scale to a high but reasonable value.
+    # scale to a high but reasonable value. See Presto docs:
+    # https://prestodb.github.io/docs/current/language/types.html#fixed-precision
     schema_overrides:
       bdecr: DECIMAL(18,10)
       bincr: DECIMAL(18,10)


### PR DESCRIPTION
This PR adds schema overrides to the table definition for `iasworld.land` in order to properly ingest the decimal part of the land rate columns.

Context: We're pulling from these columns in https://github.com/ccao-data/data-architecture/pull/678, but I noticed the decimal part of the columns was getting truncated by the default `DECIMAL(10,0)` type that we use for Oracle `NUMBER` columns that don't have precision/scale set. An analysis of the full prod data revealed that the precision/scale for these fields is all over the place:

| column | max precision | max scale |
| --- | --- | --- |
| bdecr | 2 | 0 |
| bincr | 2 | 0 |
| brate | 4 | 2 |
| bsize | 5 | 0 |
| odecr | 7 | 10 |
| oincr | 7 | 10 |
| orate | 10 | 10 |
| osize | 6 | 2 |

As such, this PR uses `DECIMAL(18, 10)`, which should preserve all of the existing values and allow for potentially larger ones without impacting query performance too much.

See `ccao.land_test_please_delete` for examples of what these columns look like after a test ingest.