### PR TITLE
Write `SparkJob` logs to the log file

### DIFF
--- a/src/utils/spark.py
+++ b/src/utils/spark.py
@@ -159,7 +159,7 @@ class SparkJob:
         # Define a logger on the class rather than the module so that joblib
         # can properly serialize it during parallelization. The addition of the
         # table name is important to avoid setting up duplicate handlers, since
-        # we expect to create once instance of this class per table
+        # we expect to create one instance of this class per table
         self.logger = create_python_logger(
             f"{__name__}.SparkJob.{strip_table_prefix(table_name)}"
         )


### PR DESCRIPTION
While debugging an unrelated issue with our ingest, I noticed that the log lines that the `SparkJob` class emits are not getting properly written to the log file, which means they don't get persisted beyond the stdout stream that prints to the console during job execution. This posed a problem for my debugging efforts, since I needed to inspect those logs, but they were not present in the log file that we upload to CloudWatch.

The root cause of the problem  is that we've been defining the logger that `SparkJob` objects use at the module level, but since we parallelize `SparkJob` calls using `joblib`, we aren't properly serializing the logger when serializing `SparkJob` objects for parallelization. This PR fixes that problem by defining a logger on `SparkJob` objects during initialization.

Note that after this change, there are still two groups of logs that Spark writes to stdout but not to the log file:

1. The info that Spark emits during session initialization, which we can't redirect to the file because [we need a session in order to create the logger](https://github.com/ccao-data/service-spark-iasworld/blob/1c1832d13fb80c87e59c59ff625cbb767853414f/src/utils/spark.py#L81-L82). Those logs look something like this:

```
24/12/16 17:57:18 INFO SparkContext: Running Spark version 3.5.1
24/12/16 17:57:18 INFO SparkContext: OS info Linux, 5.15.0-121-generic, amd64
24/12/16 17:57:18 INFO SparkContext: Java version 17.0.12
24/12/16 17:57:18 INFO ResourceUtils: ==============================================================
24/12/16 17:57:18 INFO ResourceUtils: No custom resources configured for spark.driver.
24/12/16 17:57:18 INFO ResourceUtils: ==============================================================
24/12/16 17:57:18 INFO SparkContext: Submitted application: iasworld_prod_2024-12-16_17:57:18
24/12/16 17:57:18 INFO ResourceProfile: Default ResourceProfile created, executor resources: Map(memory -> name: memory, amount: 32768, script: , vendor: , offHeap -> name: offHeap, amount: 0, script: , vendor: ), task resources: Map(cpus -> name: cpus, amount: 1.0)
24/12/16 17:57:18 INFO ResourceProfile: Limiting resource is cpu
24/12/16 17:57:18 INFO ResourceProfileManager: Added ResourceProfile id: 0
24/12/16 17:57:19 INFO SecurityManager: Changing view acls to: spark
24/12/16 17:57:19 INFO SecurityManager: Changing modify acls to: spark
24/12/16 17:57:19 INFO SecurityManager: Changing view acls groups to:
24/12/16 17:57:19 INFO SecurityManager: Changing modify acls groups to:
24/12/16 17:57:19 INFO SecurityManager: SecurityManager: authentication disabled; ui acls disabled; users with view permissions: spark; groups with view permissions: EMPTY; users with modify permissions: spark; groups with modify permissions: EMPTY
24/12/16 17:57:19 INFO Utils: Successfully started service 'sparkDriver' on port 39263.
24/12/16 17:57:19 INFO SparkEnv: Registering MapOutputTracker
24/12/16 17:57:19 INFO SparkEnv: Registering BlockManagerMaster
24/12/16 17:57:19 INFO BlockManagerMasterEndpoint: Using org.apache.spark.storage.DefaultTopologyMapper for getting topology information
24/12/16 17:57:19 INFO BlockManagerMasterEndpoint: BlockManagerMasterEndpoint up
24/12/16 17:57:19 INFO SparkEnv: Registering BlockManagerMasterHeartbeat
24/12/16 17:57:19 INFO DiskBlockManager: Created local directory at /tmp/blockmgr-ef4aa61c-4a6a-467f-a2ef-fbda490f8e88
24/12/16 17:57:19 INFO MemoryStore: MemoryStore started with capacity 1048.8 MiB
24/12/16 17:57:19 INFO SparkEnv: Registering OutputCommitCoordinator
24/12/16 17:57:19 INFO JettyUtils: Start Jetty 0.0.0.0:4041 for SparkUI
24/12/16 17:57:19 INFO Utils: Successfully started service 'SparkUI' on port 4041.
24/12/16 17:57:19 INFO SparkContext: Added JAR file:///jdbc/ojdbc8.jar at spark://spark-node-master-dev:39263/jars/ojdbc8.jar with timestamp 1734371838870
24/12/16 17:57:19 INFO StandaloneAppClient$ClientEndpoint: Connecting to master spark://spark-node-master-dev:7077...
24/12/16 17:57:19 INFO TransportClientFactory: Successfully created connection to spark-node-master-dev/<ip>:7077 after 34 ms (0 ms spent in bootstraps)
24/12/16 17:57:20 INFO StandaloneSchedulerBackend: Connected to Spark cluster with app ID app-20241216175720-0006
24/12/16 17:57:20 INFO StandaloneAppClient$ClientEndpoint: Executor added: app-20241216175720-0006/0 on worker-20241216173618-<ip>-39013 (<ip>:39013) with 16 core(s)
24/12/16 17:57:20 INFO StandaloneSchedulerBackend: Granted executor ID app-20241216175720-0006/0 on hostPort <ip>:39013 with 16 core(s), 32.0 GiB RAM
24/12/16 17:57:20 INFO Utils: Successfully started service 'org.apache.spark.network.netty.NettyBlockTransferService' on port 34835.
24/12/16 17:57:20 INFO NettyBlockTransferService: Server created on spark-node-master-dev:34835
24/12/16 17:57:20 INFO BlockManager: Using org.apache.spark.storage.RandomBlockReplicationPolicy for block replication policy
24/12/16 17:57:20 INFO BlockManagerMaster: Registering BlockManager BlockManagerId(driver, spark-node-master-dev, 34835, None)
24/12/16 17:57:20 INFO BlockManagerMasterEndpoint: Registering block manager spark-node-master-dev:34835 with 1048.8 MiB RAM, BlockManagerId(driver, spark-node-master-dev, 34835, None)
24/12/16 17:57:20 INFO BlockManagerMaster: Registered BlockManager BlockManagerId(driver, spark-node-master-dev, 34835, None)
24/12/16 17:57:20 INFO BlockManager: Initialized BlockManager: BlockManagerId(driver, spark-node-master-dev, 34835, None)
24/12/16 17:57:20 INFO StandaloneAppClient$ClientEndpoint: Executor updated: app-20241216175720-0006/0 is now RUNNING
24/12/16 17:57:20 INFO StandaloneSchedulerBackend: SchedulerBackend is ready for scheduling beginning after reached minRegisteredResourcesRatio: 0.0
```

2. A few logs that use the log name `FileOutputCommitter`, which Spark emits when writing Parquet files, and which we must somehow be missing in [the code that redirects Spark logs to a file](https://github.com/ccao-data/service-spark-iasworld/blob/1c1832d13fb80c87e59c59ff625cbb767853414f/src/utils/spark.py#L89-L110):

```
24/12/16 17:57:26 INFO FileOutputCommitter: File Output Committer Algorithm version is 1
24/12/16 17:57:26 INFO FileOutputCommitter: FileOutputCommitter skip cleanup _temporary folders under output directory:false, ignore cleanup failures: false
```

I don't think either of these two groups of logs is particularly important, so I think we can safely ignore their omission from CloudWatch unless/until it becomes a problem.