### PR TITLE
Switch to legacy Bitnami Docker image, update Python dependencies, and remove `yq`/`jq`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnamilegacy/spark:3.5.6
+FROM bitnamilegacy/spark:3.5.1
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # hadolint ignore=DL3002

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,7 @@
 FROM bitnamilegacy/spark:3.5.6
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
-# Switch to root user so we can install jq and yq for parsing JSON/YAML
-# hadolint ignore=DL3002
-USER root
-RUN mkdir -p /tmp/python && \
-    mkdir -p /var/lib/apt/lists/partial && \
-    apt-get update && \
-    apt-get install --no-install-recommends -y wget=1.21.3-1+b2 jq=1.6-2.1 && \
-    wget https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64 -q -O /usr/bin/yq && \
-    chmod +x /usr/bin/yq && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
+RUN mkdir -p /tmp/python
 COPY pyproject.toml /tmp/python
 RUN pip install --no-cache-dir /tmp/python/.
 WORKDIR /tmp/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/spark:3.5.1
+FROM bitnamilegacy/spark:3.5.6
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Switch to root user so we can install jq and yq for parsing JSON/YAML

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM bitnamilegacy/spark:3.5.1
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
-# hadolint ignore=DL3002
-USER root
 RUN mkdir -p /tmp/python
 COPY pyproject.toml /tmp/python
 RUN pip install --no-cache-dir /tmp/python/.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM bitnamilegacy/spark:3.5.6
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+# hadolint ignore=DL3002
+USER root
 RUN mkdir -p /tmp/python
 COPY pyproject.toml /tmp/python
 RUN pip install --no-cache-dir /tmp/python/.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,13 @@ license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-  "boto3==1.34.159",
-  "joblib==1.4.2",
-  "jwt==1.3.1",
-  "py4j==0.10.9.7",
-  "pyarrow==17.0.0",
-  "pyyaml==6.0.0",
-  "requests==2.32.3"
+  "boto3~=1.42.11",
+  "joblib~=1.5.3",
+  "jwt~=1.4.0",
+  "py4j~=0.10.9.9",
+  "pyarrow~=22.0.0",
+  "pyyaml~=6.0.3",
+  "requests~=2.32.5"
 ]
 
 [tool.ruff]


### PR DESCRIPTION
This PR makes a few changes to fix our Spark Docker image, which [Bitnami has recently deprecated](https://github.com/bitnami/containers/issues/83267), and hence [causing our CI builds to fail](https://github.com/ccao-data/service-spark-iasworld/actions/runs/19443076564/job/55630924596):

- Changes the base image from `bitnami/spark` ➡️ `bitnamilegacy/spark`
    - [`bitnamilegacy`](https://hub.docker.com/u/bitnamilegacy) is the archive for the old `bitnami` images, which will not receive support going forward (Bitnami is making these images subscriber-only, see the GitHub discussion linked above for documentation of this change). In the medium-term, we need to switch to a better-supported image (or roll our own), so I'm leaving https://github.com/ccao-data/service-spark-iasworld/issues/31 open to track that effort. For now, however, the legacy images are the fastest way to get builds passing again.
- Updates Python dependencies, which were slightly out of date such that a few of them could not be installed anymore
- Removes `yq` and `jq` installation, which we don't use, and definitively will never need once #32 lands

Ways I've tested this change:

- Checked that builds are now passing
- Ran a test ingest on the server using the new image to confirm that it continues to work