### PR TITLE
Update lower bound year for daily job to 2025

### DIFF
--- a/config/default_jobs/weekday_jobs.yaml
+++ b/config/default_jobs/weekday_jobs.yaml
@@ -4,7 +4,7 @@ addn:
   table_name: iasworld.addn
   # Update this year to update the rest of the minimum years in
   # the file
-  min_year: &min_year 2023
+  min_year: &min_year 2025
 aprval:
   table_name: iasworld.aprval
   min_year: *min_year


### PR DESCRIPTION
We haven't updated the lower bound for our daily import job since 2024, and it's starting to show: The daily import job used to take 30 mins, and now it takes 1.5 hours. This has started to collide with the timing for downstream jobs, most notably the IC reference file export. This PR bumps our lower bound to 2025, since the daily job only ever needs to import the two most recent years of data.