### PR TITLE
Add permissions to allow `build-docker` workflow to push to GHCR

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -11,6 +11,9 @@ name: docker-build
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # Allow workflow to push images to GHCR
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -23,7 +23,7 @@ jobs:
           # shellcheck disable=SC2129
           echo "IMAGE_TAG=$(if [ ${{ github.ref_name }} == main ]; then echo latest; elif [ ${{ github.event_name }} == release ]; then echo ${{ github.ref_name }}; else echo staging; fi)" >> "$GITHUB_ENV"
           echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
-          echo "PUSH_IMAGE=$(if [ ${{ github.event_name }} == pull_request ]; then echo true; else echo false; fi)" >> "$GITHUB_ENV"
+          echo "PUSH_IMAGE=$(if [ ${{ github.event_name }} != pull_request ]; then echo true; else echo false; fi)" >> "$GITHUB_ENV"
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -23,7 +23,7 @@ jobs:
           # shellcheck disable=SC2129
           echo "IMAGE_TAG=$(if [ ${{ github.ref_name }} == main ]; then echo latest; elif [ ${{ github.event_name }} == release ]; then echo ${{ github.ref_name }}; else echo staging; fi)" >> "$GITHUB_ENV"
           echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
-          echo "PUSH_IMAGE=$(if [ ${{ github.event_name }} != pull_request ]; then echo true; else echo false; fi)" >> "$GITHUB_ENV"
+          echo "PUSH_IMAGE=$(if [ ${{ github.event_name }} == pull_request ]; then echo true; else echo false; fi)" >> "$GITHUB_ENV"
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0


### PR DESCRIPTION
[Main branch builds are failing](https://github.com/ccao-data/service-spark-iasworld/actions/runs/26979610745/job/79615235499) due to the `build-docker` workflow not having permissions to push to the GitHub Container Registry:

> ERROR: failed to build: failed to solve: failed to push ghcr.io/ccao-data/service-spark-iasworld:latest: denied: installation not allowed to Write organization package

The workflow did not fail on the PR (#38) because it is configured to [skip pushing the image on PRs](https://github.com/ccao-data/service-spark-iasworld/blob/a4861b71a04d401c9d1340d47ba85b9d4e45d4de/.github/workflows/build-docker.yaml#L23).

This PR fixes the build error by granting the workflow the `packages: write` permission.

To be totally honest, I don't understand why this workflow was succeeding before the upgrades to our third-party Docker actions. However, the fact that it is now failing without the `packages: write` permission makes sense to me, and I'm confident that it's appropriate for us to set that permission, so I'm not too worried about the fact that I don't understand why builds weren't failing before.

I tested this change by temporarily tweaking the workflow definition to allow it to push to GHCR on PRs in [1e3d125](https://github.com/ccao-data/service-spark-iasworld/pull/39/commits/1e3d1250d4d74b6081b045c1c2b245b869ad2603), then confirmed that [the push succeeded](https://github.com/ccao-data/service-spark-iasworld/actions/runs/27219224466/job/80369255546?pr=39#step:6:282).